### PR TITLE
fix: make derivation path compatible with pallet-balances devAccounts

### DIFF
--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -338,7 +338,7 @@ pub fn generate_ecdsa_keypair(description: AccountGenerateRequest) -> EthKeypair
 		},
 		AccountGenerateRequest::Derived(seed, i) => {
 			use std::str::FromStr;
-			let derivation = format!("{SEED}{seed}//{i}");
+			let derivation = format!("{seed}//{i}");
 			let u = subxt_signer::SecretUri::from_str(&derivation).unwrap();
 			<subxt_signer::ecdsa::Keypair>::from_uri(&u).unwrap().into()
 		},
@@ -358,7 +358,7 @@ pub fn generate_sr25519_keypair(description: AccountGenerateRequest) -> SrPair {
 		},
 		AccountGenerateRequest::Derived(seed, i) => {
 			use std::str::FromStr;
-			let derivation = format!("{SEED}{seed}/{i}");
+			let derivation = format!("{seed}//{i}");
 			let u = subxt_signer::SecretUri::from_str(&derivation).unwrap();
 			<subxt_signer::sr25519::Keypair>::from_uri(&u).unwrap().into()
 		},

--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -323,7 +323,6 @@ pub enum AccountGenerateRequest {
 
 pub const SENDER_SEED: &str = "//Sender";
 pub const RECEIVER_SEED: &str = "//Receiver";
-pub const SEED: &str = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
 
 pub fn generate_ecdsa_keypair(description: AccountGenerateRequest) -> EthKeypair {
 	match description {


### PR DESCRIPTION
# Description

The seed is as simple as `//Sender` for sender on the `pallet-balances` side, so reduced it to that here too.
Seems to work fine with the accounts generated with `devAccounts` once fixed like this, not sure if more than this is needed.