### PR TITLE
csv support for load-log

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -178,13 +178,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				},
 			};
 		},
-		CliCommand::LoadLog { chain, log_file, show_graphs, .. } => match chain {
+		CliCommand::LoadLog { chain, log_file, show_graphs, out_csv_filename, .. } => match chain {
 			ChainType::Sub => {
-				let logs = Journal::<DefaultTxTask<SubstrateTransaction>>::load_logs(log_file);
+				let logs = Journal::<DefaultTxTask<SubstrateTransaction>>::load_logs(
+					log_file,
+					out_csv_filename,
+				);
 				make_stats(logs.values().cloned(), *show_graphs);
 			},
 			ChainType::Eth => {
-				let logs = Journal::<DefaultTxTask<EthTransaction>>::load_logs(log_file);
+				let logs =
+					Journal::<DefaultTxTask<EthTransaction>>::load_logs(log_file, out_csv_filename);
 				make_stats(logs.values().cloned(), *show_graphs);
 			},
 			ChainType::Fake => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,10 @@ pub enum CliCommand {
 		/// Display errors.
 		#[clap(long)]
 		show_errors: bool,
+		/// Convert loaded log file into CSV file. If specified, CSV file will be written into
+		/// given location.
+		#[clap(long)]
+		out_csv_filename: Option<String>,
 	},
 	/// Generate a list of endowed accounts.
 	GenerateEndowedAccounts {


### PR DESCRIPTION
CSV support allows to quickly find transaction hash for given min/max timings.

Some exemplary work/debug flow:
```bash
# generate a CSV file:
$ load-log ttxt_ready-txs-executor_20250227_130044.json  --out-csv-filename /tmp/sweet.csv
...
2025-03-04T16:43:20.343436Z  INFO stat: Time to in_block count=10000 min=4.350849156 max=45.889791632 mean=21.05075166914374 q90=40.34900768811542
2025-03-04T16:43:20.344037Z  INFO stat: Time to finalization count=10000 min=19.630137982 max=59.368512614 mean=36.9618818756768 q90=55.428095917247845
...

# get hashes with max in-block duration:
$ xsv sort -RN --select time_to_in_block  -d',' /tmp/sweet.csv  | xsv select hash,time_to_in_block  | head
hash,time_to_in_block
0x657e649a077eba94785c15d619a533e3ec2d1f2f89ffdc988e56239631b5913b,45889
0x17afe5f953f4bae6842e839e81cf95500b12bf6765a5ccfbc2929ee1838dd5bb,45889
0x704041d48dfd0626bcd54e151c519cee93328ad600504efe04edf281fe2fd2b2,45888
0x82a67a58699e1dc004a4629972441f55933a9deed95758bf929db429b2cffcb4,45888
0xde61a518e078a1f12ae1b8b36d23de464480bfe4fa67bbe2880d08d85d32e43c,45888
0x4f51f376c533efbc957452ed9f97a2f0817be84fe06ed899ae97b779755718fa,45888
0xb10e83de1ec9c3ba06bd93a9b643acf4e6388d7ad49841a70308f493c3161c45,45888
0xb82ee1af26190b49dc80a3a89e449f76c7fc87d37e3e2a30fd0afd7b55924a56,45887
0xac465f0e57a2798039d367f048e2bab5e019b8d294660f80e5b10ae927c1eccf,45887

# get hashes with min finalization duration:
$ xsv sort -N --select time_to_finalized  -d',' /tmp/sweet.csv  | xsv select hash,time_to_finalized | less
hash,time_to_finalized
0x7b027053346e69489e6d133b1b7b5900fb393c58c48da7727084724e2a6f0dce,19630
0xeaa70da222fac143058be531b473f1c5cd022c557539d34b6d67fc02d39448ea,19631
0x872df50ab3787cdeeba0982536650b9e5686c4bd970cdfc6c7e30331de9882a7,19631
0xb465b793e84670dc488c6df3a79bcb67083e0e4e35ea972bde4c7d5fe0f92ee6,19631
0x392141be84e82ecad9cc6c73917bdf1e629de353eac297dbf0bc2d365fe53a03,19631
0x8ea07698bfcad67de2adbf7c3a21c0f128384fceb08859c1d9e4939824a0a260,19631
```

This way we can find hashes for min finalization (19.63s as seen in load-log report):
```
stat: Time to finalization count=10000 min=19.630137982 max=59.368512614 mean=36.9618818756768 q90=55.428095917247845
```
and max in-block (45.89s):
```
stat: Time to in_block count=10000 min=4.350849156 max=45.889791632 mean=21.05075166914374 q90=40.34900768811542
```

