### PR TITLE
bump to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7af3d1149d6063985bb62d97f3ea83060ce4d6f2d04c21f551d270e8d84a27c"
+checksum = "50c554ce2394e2c04426a070b4cb133c72f6f14c86b665f4e13094addd8e8958"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "18.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
+checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -2822,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3173be608895eb117cf397ab4f31f00e2ed2c7af1c6e0b8f5d51d0a0967053"
+checksum = "6aebea322734465f39e4ad8100e1f9708c6c6c325d92b8780015d30c44fae791"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3311,7 +3311,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "substrate-txtesttool"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "average",
@@ -3330,6 +3330,7 @@ dependencies = [
  "serde_json",
  "subxt",
  "subxt-core",
+ "subxt-rpcs",
  "subxt-signer",
  "termplot",
  "thiserror 2.0.12",
@@ -3348,9 +3349,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffca95192207f6dbaf68a032f7915cfc8670f062df0464bdddf05d35a09bcf8"
+checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -3358,7 +3359,6 @@ dependencies = [
  "frame-metadata",
  "futures",
  "hex",
- "impl-serde",
  "jsonrpsee",
  "parity-scale-codec",
  "primitive-types",
@@ -3374,6 +3374,7 @@ dependencies = [
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
+ "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -3385,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de8786ebc4be0905fac861c8ce1845e677a96b8ddb209e5c3e0e1f6b804d62f"
+checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -3402,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa812fea5d2a104d3253aa722daa51f222cf951304f4d47eda70c268bf99921"
+checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
 dependencies = [
  "base58",
  "blake2",
@@ -3432,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbf1a87957918fcfde2cc2150d792c752acb933f0f83262a8b42d96b8dfcc52"
+checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
 dependencies = [
  "futures",
  "futures-util",
@@ -3449,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a120bac6a4a07d477e736f42a388eebef47a277d2a76c8cddcf90e71ee4aa2"
+checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -3465,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcee71f170e496294434c7c8646befc05e9a3a27a771712b4f3008d0c4d0ee7"
+checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -3479,10 +3480,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "subxt-signer"
-version = "0.40.0"
+name = "subxt-rpcs"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ea55baf5930de2ad53d2cd1371b083cbeecad1fd2f7b6eb9f16db1496053fa"
+checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+dependencies = [
+ "derive-where",
+ "frame-metadata",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "subxt-core",
+ "subxt-lightclient",
+ "thiserror 2.0.12",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "subxt-signer"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -3510,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721556230144393c58ff3dd2660f734cc792fe19167823b957d6858b15e12362"
+checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-txtesttool"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A library and CLI tool for sending transactions to substrate-based chains, enabling developers to test and monitor transaction scenarios."
 license = "Apache-2.0 OR GPL-3.0"
@@ -30,9 +30,10 @@ parking_lot = "0.12.3"
 rand = "0.9.0"
 serde = "1.0.204"
 serde_json = { version = "1.0.121", features = ["arbitrary_precision"] }
-subxt = { version = "0.40.0" }
-subxt-core = "0.40.0"
-subxt-signer = { version = "0.40.0", features = ["unstable-eth"] }
+subxt = { version = "0.41.0" }
+subxt-core = "0.41.0"
+subxt-rpcs = "0.41.0"
+subxt-signer = { version = "0.41.0", features = ["unstable-eth"] }
 termplot = "0.1.1"
 thiserror = "2.0.11"
 time = { version = "0.3.36", features = [

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -463,7 +463,7 @@ mod tests {
 		);
 
 		let tx = EthTransaction::new(
-			api.tx().create_signed_offline(&tx_call, &baltathar, tx_params).unwrap(),
+			api.tx().create_partial_offline(&tx_call, tx_params).unwrap().sign(&baltathar),
 			nonce as u128,
 			AccountMetadata::KeyRing("baltathar".to_string()),
 		);

--- a/src/subxt_api_connector.rs
+++ b/src/subxt_api_connector.rs
@@ -19,6 +19,7 @@ pub(crate) async fn connect<C: subxt::Config>(
 	for i in 0..MAX_ATTEMPTS {
 		info!("Attempt #{}: Connecting to {}", i, url);
 		let backend = subxt::backend::chain_head::ChainHeadBackend::builder()
+			.transaction_timeout(6 * 3600)
 			.build_with_background_driver(subxt::backend::rpc::RpcClient::new(
 				helpers::client(url).await?,
 			));


### PR DESCRIPTION
- Bumped version to 0.5.0,
- bump subxt to 0.41.0 and fix the code,
- increased transcation timeout (https://github.com/paritytech/subxt/issues/1942)
