### PR TITLE
added `submit_transactions_ignoring_follow_events`

### DIFF
--- a/src/subxt_api_connector.rs
+++ b/src/subxt_api_connector.rs
@@ -20,6 +20,7 @@ pub(crate) async fn connect<C: subxt::Config>(
 		info!("Attempt #{}: Connecting to {}", i, url);
 		let backend = subxt::backend::chain_head::ChainHeadBackend::builder()
 			.transaction_timeout(6 * 3600)
+			.submit_transactions_ignoring_follow_events()
 			.build_with_background_driver(subxt::backend::rpc::RpcClient::new(
 				helpers::client(url).await?,
 			));


### PR DESCRIPTION
See for some more details: https://github.com/paritytech/subxt/issues/1956

Rarely tests were failing with following enabled.
