### PR TITLE
add support for sending mortal txs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "substrate-txtesttool"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "average",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1147,11 +1147,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c554ce2394e2c04426a070b4cb133c72f6f14c86b665f4e13094addd8e8958"
+checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
 dependencies = [
- "frame-metadata",
+ "frame-metadata 21.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -1169,6 +1169,17 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]
@@ -2690,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
 ]
 
 [[package]]
@@ -2822,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aebea322734465f39e4ad8100e1f9708c6c6c325d92b8780015d30c44fae791"
+checksum = "05c61b6b706a3eaad63b506ab50a1d2319f817ae01cf753adcc3f055f9f0fcd6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3161,7 +3172,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener",
@@ -3211,7 +3222,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener",
  "fnv",
@@ -3356,7 +3367,7 @@ dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
  "jsonrpsee",
@@ -3411,7 +3422,7 @@ dependencies = [
  "blake2",
  "derive-where",
  "frame-decode",
- "frame-metadata",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde",
@@ -3471,7 +3482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
  "frame-decode",
- "frame-metadata",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
@@ -3486,7 +3497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
 dependencies = [
  "derive-where",
- "frame-metadata",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
  "impl-serde",
@@ -3700,9 +3711,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-txtesttool"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A library and CLI tool for sending transactions to substrate-based chains, enabling developers to test and monitor transaction scenarios."
 license = "Apache-2.0 OR GPL-3.0"
@@ -15,9 +15,9 @@ async-trait = "0.1.81"
 futures = "0.3.30"
 futures-util = "0.3.30"
 jsonrpsee = { version = "0.24.8", features = [
-    "async-client",
-    "client-web-transport",
-    "jsonrpsee-types",
+  "async-client",
+  "client-web-transport",
+  "jsonrpsee-types",
 ] }
 average = "0.15.1"
 chrono = "0.4.38"
@@ -37,20 +37,20 @@ subxt-signer = { version = "0.41.0", features = ["unstable-eth"] }
 termplot = "0.1.1"
 thiserror = "2.0.11"
 time = { version = "0.3.36", features = [
-    "formatting",
-    "local-offset",
-    "macros",
+  "formatting",
+  "local-offset",
+  "macros",
 ] }
 tokio = { version = "1.39.1", features = [
-    "macros",
-    "rt-multi-thread",
-    "sync",
-    "time",
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "time",
 ] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [
-    "env-filter",
-    "fmt",
-    "time",
+  "env-filter",
+  "fmt",
+  "time",
 ] }

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				scenario_builder = populate_scenario_builder!(scenario_builder, scenario);
 
 				if let Some(mortality) = mortal {
-					scenario_builder = scenario_builder.with_mortality(mortal);
+					scenario_builder = scenario_builder.with_mortality(*mortality);
 				}
 
 				if let Some(inner) = remark {

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -77,10 +77,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 				scenario_builder = populate_scenario_builder!(scenario_builder, scenario);
 
-				// TODO: not sure if these are supposed to work the same as for substrate
-				// if let Some(mortality) = mortal {
-				// 	scenario_builder = scenario_builder.with_mortality(mortal);
-				// }
+				if let Some(mortality) = mortal {
+					scenario_builder = scenario_builder.with_mortality(mortal);
+				}
 
 				if let Some(inner) = remark {
 					scenario_builder = scenario_builder.with_remark_recipe(*inner);

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -77,6 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 				scenario_builder = populate_scenario_builder!(scenario_builder, scenario);
 
+				// TODO: not sure if these are supposed to work the same as for substrate
+				// if let Some(mortality) = mortal {
+				// 	scenario_builder = scenario_builder.with_mortality(mortal);
+				// }
+
 				if let Some(inner) = remark {
 					scenario_builder = scenario_builder.with_remark_recipe(*inner);
 				}
@@ -96,6 +101,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 					.with_tip(*tip);
 
 				scenario_builder = populate_scenario_builder!(scenario_builder, scenario);
+
+				if let Some(mortality) = mortal {
+					scenario_builder = scenario_builder.with_mortality(*mortality);
+				}
 
 				if let Some(inner) = remark {
 					scenario_builder = scenario_builder.with_remark_recipe(*inner);

--- a/src/block_monitor.rs
+++ b/src/block_monitor.rs
@@ -170,10 +170,10 @@ impl<C: subxt::Config> BlockMonitor<C> {
 					trace!("listener_request: {:?}", hash);
 					callbacks.insert(hash, tx);
 					if let Some(till) = valid_until {
-                        mortal_accounting
-                            .entry(till)
-                            .or_insert_with(HashSet::new)
-                            .insert(hash);
+						mortal_accounting
+							.entry(till)
+							.or_default()
+							.insert(hash);
 					}
 				}
 			}

--- a/src/block_monitor.rs
+++ b/src/block_monitor.rs
@@ -33,7 +33,7 @@ type TxFoundListenerTrigger<H> = oneshot::Sender<Result<H, Error>>;
 /// It is based on a tuple containing (transaction hash, maybe_mortality, channel sending end).
 type ListenerInfo<C> = (HashOf<C>, Option<u64>, TxFoundListenerTrigger<HashOf<C>>);
 /// Receiving end of a channel used by block monitor to register unwatched transactions
-/// finalization.
+/// finalization listener.
 type TxSubmissionListener<C> = mpsc::Receiver<ListenerInfo<C>>;
 /// Sending end of a channel used by the runner to submit to the block monitor a listener for
 /// unwatched transactions finalization.

--- a/src/block_monitor.rs
+++ b/src/block_monitor.rs
@@ -70,7 +70,8 @@ impl<C: subxt::Config> TransactionMonitor<HashOf<C>> for BlockMonitor<C> {
 			// first map the outer elapsed error if any
 			.map_err(|elapsed| {
 				Error::Other(format!(
-					"waiting for mortal tx finalization timed out after {elapsed} seconds"
+					"waiting for mortal tx finalization timed out after {} seconds",
+					elapsed
 				))
 			})
 			.and_then(|res| res)

--- a/src/block_monitor.rs
+++ b/src/block_monitor.rs
@@ -170,13 +170,10 @@ impl<C: subxt::Config> BlockMonitor<C> {
 					trace!("listener_request: {:?}", hash);
 					callbacks.insert(hash, tx);
 					if let Some(till) = valid_until {
-						if let Some(txs) = mortal_accounting.get_mut(&till) {
-							txs.insert(hash);
-						} else {
-							let mut txs = HashSet::new();
-							txs.insert(hash);
-							mortal_accounting.insert(till, txs);
-						}
+                        mortal_accounting
+                            .entry(till)
+                            .or_insert_with(HashSet::new)
+                            .insert(hash);
 					}
 				}
 			}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub enum CliCommand {
 		block_monitor: bool,
 		/// Use mortal transactions.
 		#[clap(long)]
-		mortal: Option<u32>,
+		mortal: Option<u64>,
 		/// Send transactions threshold, sends the batch when number of pedning extrinsics drops
 		/// below this number.
 		#[clap(long, default_value_t = 10000)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,8 @@ pub enum CliCommand {
 		/// Spawn block monitor for checking if transactions are included in finalized blocks.
 		#[clap(long)]
 		block_monitor: bool,
-		/// Use mortal transactions.
+		/// Use mortal transactions. This represents the number of blocks the mortal tx is valid
+		/// for, starting with the current block at the time of submission.
 		#[clap(long)]
 		mortal: Option<u64>,
 		/// Send transactions threshold, sends the batch when number of pedning extrinsics drops

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub enum CliCommand {
 		#[clap(long)]
 		block_monitor: bool,
 		/// Use mortal transactions. This represents the number of blocks the mortal tx is valid
-		/// for, starting with the current block at the time of submission.
+		/// for, starting with the current finalized block at the time of tx creation.
 		#[clap(long)]
 		mortal: Option<u64>,
 		/// Send transactions threshold, sends the batch when number of pedning extrinsics drops

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,4 +13,7 @@ pub enum Error {
 	/// Other error.
 	#[error("Other error: {0}")]
 	Other(String),
+	/// Mortal transaction lifetime surpassed
+	#[error("Mortal transaction lifetime surpassed")]
+	MortalLifetimeSurpassed(u64),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,6 @@ pub enum Error {
 	#[error("Other error: {0}")]
 	Other(String),
 	/// Mortal transaction lifetime surpassed
-	#[error("Mortal transaction lifetime surpassed")]
+	#[error("Mortal transaction lifetime surpassed, block number: {0}")]
 	MortalLifetimeSurpassed(u64),
 }

--- a/src/execution_log.rs
+++ b/src/execution_log.rs
@@ -166,6 +166,9 @@ pub trait ExecutionLog: Sync + Send {
 	/// Returns the hash of the finalized block, if available.
 	fn finalized(&self) -> Option<Self::HashType>;
 
+	/// Returns the dropped txs and their reason.
+	fn dropped(&self) -> Option<String>;
+
 	/// Determines if the transaction's progress is being monitored. If not, some events are not
 	/// available.
 	fn is_watched(&self) -> bool;
@@ -342,6 +345,14 @@ impl<H: BlockHash + 'static> ExecutionLog for TransactionExecutionLog<H> {
 	fn finalized(&self) -> Option<Self::HashType> {
 		self.events.read().iter().find_map(|e| match e {
 			ExecutionEvent::TxPoolEvent(_, TransactionStatus::Finalized(h)) => Some(*h),
+			_ => None,
+		})
+	}
+
+	fn dropped(&self) -> Option<String> {
+		self.events.read().iter().find_map(|e| match e {
+			ExecutionEvent::TxPoolEvent(_, TransactionStatus::Dropped(reason)) =>
+				Some(reason.clone()),
 			_ => None,
 		})
 	}

--- a/src/execution_log.rs
+++ b/src/execution_log.rs
@@ -166,9 +166,6 @@ pub trait ExecutionLog: Sync + Send {
 	/// Returns the hash of the finalized block, if available.
 	fn finalized(&self) -> Option<Self::HashType>;
 
-	/// Returns the dropped txs and their reason.
-	fn dropped(&self) -> Option<String>;
-
 	/// Determines if the transaction's progress is being monitored. If not, some events are not
 	/// available.
 	fn is_watched(&self) -> bool;
@@ -345,14 +342,6 @@ impl<H: BlockHash + 'static> ExecutionLog for TransactionExecutionLog<H> {
 	fn finalized(&self) -> Option<Self::HashType> {
 		self.events.read().iter().find_map(|e| match e {
 			ExecutionEvent::TxPoolEvent(_, TransactionStatus::Finalized(h)) => Some(*h),
-			_ => None,
-		})
-	}
-
-	fn dropped(&self) -> Option<String> {
-		self.events.read().iter().find_map(|e| match e {
-			ExecutionEvent::TxPoolEvent(_, TransactionStatus::Dropped(reason)) =>
-				Some(reason.clone()),
 			_ => None,
 		})
 	}

--- a/src/execution_log.rs
+++ b/src/execution_log.rs
@@ -37,6 +37,7 @@ pub enum ExecutionEvent<H> {
 	SubmitAndWatchResult(SystemTime, Result<(), String>),
 	TxPoolEvent(SystemTime, TransactionStatus<H>),
 	FinalizedMonitor(SystemTime, H),
+	MortalDroppedMonitor(SystemTime, u64),
 }
 
 impl<H: BlockHash + DeserializeOwned + std::fmt::Debug> ExecutionEvent<H> {}
@@ -57,6 +58,9 @@ impl<H: BlockHash> ExecutionEvent<H> {
 	pub fn finalized_monitor(block_hash: H) -> Self {
 		Self::FinalizedMonitor(SystemTime::now(), block_hash)
 	}
+	pub fn mortal_dropped_monitor(block_number: u64) -> Self {
+		Self::MortalDroppedMonitor(SystemTime::now(), block_number)
+	}
 }
 
 impl<H: BlockHash> From<TransactionStatus<H>> for ExecutionEvent<H> {
@@ -74,6 +78,7 @@ pub struct Counters {
 	submit_and_watch_success: AtomicUsize,
 	submit_and_watch_error: AtomicUsize,
 	finalized_monitor: AtomicUsize,
+	mortal_dropped_monitor: AtomicUsize,
 
 	ts_validated: AtomicUsize,
 	ts_broadcasted: AtomicUsize,
@@ -139,6 +144,7 @@ impl Counters {
 				TransactionStatus::NoLongerInBestBlock => {},
 			},
 			ExecutionEvent::Resubmitted(_) => {},
+			ExecutionEvent::MortalDroppedMonitor(_, _) => Self::inc(&self.mortal_dropped_monitor),
 		}
 	}
 }
@@ -199,6 +205,13 @@ pub trait ExecutionLog: Sync + Send {
 
 	/// Returns the duration to finalization as monitored by an external observer.
 	fn time_to_finalized_monitor(&self) -> Option<Duration>;
+
+	/// Returns the duration to mortal dropped as monitored by an external observer.
+	///
+	/// The correct moment a transaction is blocked is not known by simply looking at the finalize
+	/// blocks, but when the tx is dropped, this represents the time it took to declare it as
+	/// dropped/invalid.
+	fn time_to_mortal_dropped_monitor(&self) -> Option<Duration>;
 
 	/// Retrieves reasons for invalidation of the transaction.
 	fn get_invalid_reason(&self) -> Vec<String>;
@@ -349,6 +362,14 @@ impl<H: BlockHash + 'static> ExecutionLog for TransactionExecutionLog<H> {
 	fn time_to_finalized_monitor(&self) -> Option<Duration> {
 		let fmts = self.events.read().iter().find_map(|e| match e {
 			ExecutionEvent::FinalizedMonitor(i, _) => Some(*i),
+			_ => None,
+		});
+		Self::duration_since_timestamp(self.get_sent_time_stamp(), fmts)
+	}
+
+	fn time_to_mortal_dropped_monitor(&self) -> Option<Duration> {
+		let fmts = self.events.read().iter().find_map(|e| match e {
+			ExecutionEvent::MortalDroppedMonitor(i, _) => Some(*i),
 			_ => None,
 		});
 		Self::duration_since_timestamp(self.get_sent_time_stamp(), fmts)

--- a/src/execution_log.rs
+++ b/src/execution_log.rs
@@ -599,6 +599,12 @@ pub fn make_stats<E: ExecutionLog>(logs: impl IntoIterator<Item = Arc<E>>, show_
 		E::time_to_finalized_monitor,
 		show_graphs,
 	);
+	single_stat(
+		"Time to dropped (monitor)".into(),
+		logs.iter(),
+		E::time_to_mortal_dropped_monitor,
+		show_graphs,
+	);
 
 	failure_reason_stats("Dropped".into(), logs.iter(), E::get_dropped_reason);
 	failure_reason_stats("Error".into(), logs.iter(), E::get_error_reason);

--- a/src/fake_transaction.rs
+++ b/src/fake_transaction.rs
@@ -140,6 +140,9 @@ impl Transaction for FakeTransaction {
 	fn account_metadata(&self) -> AccountMetadata {
 		self.account_metadata.clone()
 	}
+	fn mortality(&self) -> &Option<u64> {
+		&None
+	}
 }
 
 #[allow(dead_code)]

--- a/src/fake_transaction.rs
+++ b/src/fake_transaction.rs
@@ -140,7 +140,7 @@ impl Transaction for FakeTransaction {
 	fn account_metadata(&self) -> AccountMetadata {
 		self.account_metadata.clone()
 	}
-	fn mortality(&self) -> &Option<u64> {
+	fn valid_until(&self) -> &Option<u64> {
 		&None
 	}
 }

--- a/src/fake_transaction_sink.rs
+++ b/src/fake_transaction_sink.rs
@@ -63,7 +63,7 @@ impl TransactionsSink<FakeHash> for FakeTransactionsSink {
 		self.txs.read().len()
 	}
 
-	fn block_monitor(&self) -> Option<&dyn TransactionMonitor<FakeHash>> {
+	fn transaction_monitor(&self) -> Option<&dyn TransactionMonitor<FakeHash>> {
 		None
 	}
 }

--- a/src/fake_transaction_sink.rs
+++ b/src/fake_transaction_sink.rs
@@ -63,7 +63,7 @@ impl TransactionsSink<FakeHash> for FakeTransactionsSink {
 		self.txs.read().len()
 	}
 
-	fn transaction_monitor(&self) -> Option<&dyn TransactionMonitor<FakeHash>> {
+	fn block_monitor(&self) -> Option<&dyn TransactionMonitor<FakeHash>> {
 		None
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     let scenario_executor = ScenarioBuilder::new()
 //!         .with_rpc_uri(ws.to_string())
 //!         .with_chain_type(ChainType::Sub)
-//!         .with_block_monitoring(block_monitor)
+//!         .with_block_monitoring(true)
 //!         .with_start_id("0".to_string())
 //!         .with_last_id(99)
 //!         .with_nonce_from(Some(0))

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -23,7 +23,7 @@ use tokio::{
 	select,
 	sync::mpsc::{channel, Receiver, Sender},
 };
-use tracing::{debug, info, instrument, trace, warn, Span};
+use tracing::{debug, error, info, instrument, trace, warn, Span};
 
 const LOG_TARGET: &str = "runner";
 
@@ -159,7 +159,10 @@ impl<H: BlockHash, T: Transaction<HashType = H> + Send> TxTask for DefaultTxTask
 								Error::MortalLifetimeSurpassed(block_number) => log.push_event(
 									ExecutionEvent::mortal_dropped_monitor(block_number),
 								),
-								_ => log.push_event(ExecutionEvent::submit_result(Err(err))),
+								_ => {
+									error!(target: LOG_TARGET, ?err, "error while waiting for transaction");
+									log.push_event(ExecutionEvent::submit_result(Err(err)))
+								},
 							};
 							ExecutionResult::Error(self.tx().hash())
 						},

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -145,9 +145,9 @@ impl<H: BlockHash, T: Transaction<HashType = H> + Send> TxTask for DefaultTxTask
 		log.push_event(ExecutionEvent::sent());
 
 		match rpc.submit(self.tx()).await {
-			Ok(_) =>
+			Ok(_) => {
+				log.push_event(ExecutionEvent::submit_result(Ok(())));
 				if let Some(monitor) = rpc.transaction_monitor() {
-					log.push_event(ExecutionEvent::submit_result(Ok(())));
 					match monitor.wait(self.tx().hash(), *self.tx().valid_until()).await {
 						Ok(block_hash) => {
 							log.push_event(ExecutionEvent::finalized_monitor(block_hash));
@@ -160,7 +160,8 @@ impl<H: BlockHash, T: Transaction<HashType = H> + Send> TxTask for DefaultTxTask
 					}
 				} else {
 					ExecutionResult::Done(self.tx().hash())
-				},
+				}
+			},
 			Err(e) => {
 				log.push_event(ExecutionEvent::submit_result(Err(e)));
 				ExecutionResult::Error(self.tx().hash())

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -146,7 +146,7 @@ impl<H: BlockHash, T: Transaction<HashType = H> + Send> TxTask for DefaultTxTask
 		match rpc.submit(self.tx()).await {
 			Ok(_) => {
 				//todo: block monitor await here (with some global (cli-provided) timeout)
-				if let Some(monitor) = rpc.block_monitor() {
+				if let Some(monitor) = rpc.transaction_monitor() {
 					if let Some(mortality) = self.tx().mortality() {
 						tokio::time::timeout(
 							// Consider that 10 blocks are worth a minute

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -267,14 +267,19 @@ impl ScenarioBuilder {
 		self
 	}
 
-	/// The builder is already initialised with a transfer transaction recipe with a tip of 0
-	/// and this API lets builders set it specifically with a certain tip amount.
+	/// Sets transaction recipe to a regular balances transfer.
+	///
+	/// The builder is already initialised with a transfer transaction recipe with a tip of 0.
+	/// If a tip is set, the builder will update the tip of the transaction recipe accordingly.
 	pub fn with_transfer_recipe(mut self) -> Self {
 		self.tx_recipe = Some(TransactionRecipe::transfer(self.tip));
 		self
 	}
 
-	/// Set a remark transaction recipe with a certain tip.
+	/// Set a remark transaction recipe.
+	///
+	/// If a tip is set, the builder will update the tip of the transaction recipe
+	/// accordingly.
 	pub fn with_remark_recipe(mut self, remark: u32) -> Self {
 		self.tx_recipe = Some(TransactionRecipe::remark(remark, self.tip));
 		self

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -301,7 +301,8 @@ impl ScenarioBuilder {
 		self
 	}
 
-	/// Sets for how many blocks a transaction is considered valid, and expected to finalize.
+	/// Sets for how many blocks a transaction is considered valid.
+	///
 	/// Note: using this setter can increase the transaction creation times which can impact heavy
 	/// load tests that create millions of transactions. This method instructs a scenario to use
 	/// an online client for txs creation, since creating mortal txs requires knowledge about the

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -302,6 +302,10 @@ impl ScenarioBuilder {
 	}
 
 	/// Sets for how many blocks a transaction is considered valid, and expected to finalize.
+	/// Note: using this setter can increase the transaction creation times which can impact heavy
+	/// load tests that create millions of transactions. This method instructs a scenario to use
+	/// an online client for txs creation, since creating mortal txs requires knowledge about the
+	/// last finalized block on chain.
 	pub fn with_mortality(mut self, mortality: u64) -> Self {
 		self.mortality = Some(mortality);
 		self

--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -58,8 +58,9 @@ pub(crate) type HashOf<C> = <C as subxt::Config>::Hash;
 pub(crate) type AccountIdOf<C> = <C as subxt::Config>::AccountId;
 
 /// A subxt transaction abstraction.
+#[derive(Clone)]
 pub struct SubxtTransaction<C: subxt::Config> {
-	transaction: SubmittableTransaction<C, OnlineClient<C>>,
+	transaction: Arc<SubmittableTransaction<C, OnlineClient<C>>>,
 	nonce: u128,
 	mortality: Option<u64>,
 	account_metadata: AccountMetadata,
@@ -81,7 +82,7 @@ impl<C: subxt::Config> SubxtTransaction<C> {
 		mortality: Option<u64>,
 		account_metadata: AccountMetadata,
 	) -> Self {
-		Self { transaction, nonce, account_metadata, mortality }
+		Self { transaction: Arc::new(transaction), nonce, account_metadata, mortality }
 	}
 }
 

--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -505,6 +505,7 @@ pub(crate) fn build_eth_tx_payload(
 	}
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn create_transaction<C: subxt::Config, KP, G>(
 	from_keypair: &KP,
 	nonce: u128,
@@ -694,11 +695,11 @@ where
 			sink,
 			&from_account_id,
 			&to_account_id,
-			&recipe,
+			recipe,
 			generate_payload,
 		)
 		.await
-		.unwrap()
+		.expect("failed to create mortal transaction")
 	} else {
 		let params = <SubstrateExtrinsicParamsBuilder<C>>::new()
 			.nonce(nonce as u64)

--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -309,7 +309,7 @@ where
 			.1
 	}
 
-	fn block_monitor(&self) -> Option<&dyn TransactionMonitor<<C as subxt::Config>::Hash>> {
+	fn transaction_monitor(&self) -> Option<&dyn TransactionMonitor<<C as subxt::Config>::Hash>> {
 		self.block_monitor
 			.as_ref()
 			.map(|m| m as &dyn TransactionMonitor<<C as subxt::Config>::Hash>)

--- a/src/subxt_transaction.rs
+++ b/src/subxt_transaction.rs
@@ -685,30 +685,31 @@ where
 		"build_subxt_tx"
 	);
 
-	if let Ok(tx) = create_transaction(
-		&from_keypair,
-		nonce,
-		mortality,
-		account,
-		sink,
-		&from_account_id,
-		&to_account_id,
-		&recipe,
-		generate_payload,
-	)
-	.await
-	{
-		tx
+	if mortality.is_some() {
+		create_transaction(
+			&from_keypair,
+			nonce,
+			mortality,
+			account,
+			sink,
+			&from_account_id,
+			&to_account_id,
+			&recipe,
+			generate_payload,
+		)
+		.await
+		.unwrap()
 	} else {
 		let params = <SubstrateExtrinsicParamsBuilder<C>>::new()
 			.nonce(nonce as u64)
 			.tip(recipe.tip)
-			.build();
+			.build()
+			.into();
 		let tx_call = generate_payload(to_account_id, recipe);
 		let tx = SubxtTransaction::<C>::new(
 			sink.api()
 				.tx()
-				.create_partial_offline(&tx_call, params.into())
+				.create_partial_offline(&tx_call, params)
 				.unwrap()
 				.sign(&from_keypair),
 			nonce as u128,
@@ -718,9 +719,6 @@ where
 		debug!(target:LOG_TARGET,"built immortal tx hash: {:?}", tx.hash());
 		tx
 	}
-
-	// } else {
-	// 	}
 }
 
 #[cfg(test)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -252,7 +252,7 @@ pub trait Transaction: Send + Sync {
 	fn hash(&self) -> Self::HashType;
 	fn as_any(&self) -> &dyn Any;
 	fn nonce(&self) -> u128;
-	fn mortality(&self) -> &Option<u64>;
+	fn valid_until(&self) -> &Option<u64>;
 	fn account_metadata(&self) -> AccountMetadata;
 }
 
@@ -261,8 +261,8 @@ pub trait Transaction: Send + Sync {
 pub trait TransactionMonitor<H: BlockHash> {
 	/// Wait for the transaction to finalize.
 	///
-	/// If tx is mortal, mortality parameter should be considered when waiting for finalization.
-	async fn wait(&self, tx_hash: H, mortality: &Option<u64>) -> Result<H, Error>;
+	/// An optional block number is given to be considered for waiting when needed.
+	async fn wait(&self, tx_hash: H, until: Option<u64>) -> Result<H, Error>;
 }
 
 /// Abstraction for RPC client

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -30,6 +30,7 @@ pub(crate) trait TransactionBuilder {
 		&self,
 		account: &'a str,
 		nonce: &Option<u128>,
+		mortality: &Option<u64>,
 		sink: &Self::Sink,
 		watched: bool,
 		recipe: &TransactionRecipe,
@@ -49,17 +50,20 @@ impl TransactionBuilder for SubstrateTransactionBuilder {
 		&self,
 		account: &'a str,
 		nonce: &Option<u128>,
+		mortality: &Option<u64>,
 		sink: &Self::Sink,
 		watched: bool,
 		recipe: &TransactionRecipe,
 	) -> DefaultTxTask<Self::Transaction> {
 		if !watched {
 			DefaultTxTask::<Self::Transaction>::new_unwatched(
-				build_subxt_tx(account, nonce, sink, recipe, build_substrate_tx_payload).await,
+				build_subxt_tx(account, nonce, mortality, sink, recipe, build_substrate_tx_payload)
+					.await,
 			)
 		} else {
 			DefaultTxTask::<Self::Transaction>::new_watched(
-				build_subxt_tx(account, nonce, sink, recipe, build_substrate_tx_payload).await,
+				build_subxt_tx(account, nonce, mortality, sink, recipe, build_substrate_tx_payload)
+					.await,
 			)
 		}
 	}
@@ -78,17 +82,18 @@ impl TransactionBuilder for EthTransactionBuilder {
 		&self,
 		account: &'a str,
 		nonce: &Option<u128>,
+		mortality: &Option<u64>,
 		sink: &Self::Sink,
 		watched: bool,
 		recipe: &TransactionRecipe,
 	) -> DefaultTxTask<Self::Transaction> {
 		if !watched {
 			DefaultTxTask::<Self::Transaction>::new_unwatched(
-				build_subxt_tx(account, nonce, sink, recipe, build_eth_tx_payload).await,
+				build_subxt_tx(account, nonce, mortality, sink, recipe, build_eth_tx_payload).await,
 			)
 		} else {
 			DefaultTxTask::<Self::Transaction>::new_watched(
-				build_subxt_tx(account, nonce, sink, recipe, build_eth_tx_payload).await,
+				build_subxt_tx(account, nonce, mortality, sink, recipe, build_eth_tx_payload).await,
 			)
 		}
 	}
@@ -108,6 +113,7 @@ impl TransactionBuilder for FakeTransactionBuilder {
 		&self,
 		account: &'a str,
 		_nonce: &Option<u128>,
+		_mortality: &Option<u64>,
 		sink: &Self::Sink,
 		unwatched: bool,
 		_recipe: &TransactionRecipe,
@@ -198,7 +204,7 @@ impl<H> TransactionStatus<H> {
 	pub(crate) fn get_letter(&self) -> char {
 		match self {
 			TransactionStatus::Validated => 'V',
-			TransactionStatus::Broadcasted { .. } => 'b',
+			TransactionStatus::Broadcasted => 'b',
 			TransactionStatus::InBlock(..) => 'B',
 			TransactionStatus::Finalized(..) => 'F',
 			TransactionStatus::Error { .. } => 'E',

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -259,7 +259,10 @@ pub trait Transaction: Send + Sync {
 /// Interface for monitoring transaction state.
 #[async_trait]
 pub trait TransactionMonitor<H: BlockHash> {
-	async fn wait(&self, tx_hash: H) -> H;
+	/// Wait for the transaction to finalize.
+	///
+	/// If tx is mortal, mortality parameter should be considered when waiting for finalization.
+	async fn wait(&self, tx_hash: H, mortality: &Option<u64>) -> Result<H, Error>;
 }
 
 /// Abstraction for RPC client

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -252,6 +252,7 @@ pub trait Transaction: Send + Sync {
 	fn hash(&self) -> Self::HashType;
 	fn as_any(&self) -> &dyn Any;
 	fn nonce(&self) -> u128;
+	fn mortality(&self) -> &Option<u64>;
 	fn account_metadata(&self) -> AccountMetadata;
 }
 
@@ -274,5 +275,5 @@ pub trait TransactionsSink<H: BlockHash>: Send + Sync {
 	///Current count of transactions being processed by sink
 	async fn pending_extrinsics(&self) -> usize;
 
-	fn transaction_monitor(&self) -> Option<&dyn TransactionMonitor<H>>;
+	fn block_monitor(&self) -> Option<&dyn TransactionMonitor<H>>;
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -275,5 +275,5 @@ pub trait TransactionsSink<H: BlockHash>: Send + Sync {
 	///Current count of transactions being processed by sink
 	async fn pending_extrinsics(&self) -> usize;
 
-	fn block_monitor(&self) -> Option<&dyn TransactionMonitor<H>>;
+	fn transaction_monitor(&self) -> Option<&dyn TransactionMonitor<H>>;
 }


### PR DESCRIPTION
This PR takes the mortal flag value passed in CLI and passes it over up to subxt transaction building, where we can configure its tx params to contain the mortality.

Closes #14 

### Review notes

TODO:
- ~test this work by writing a scenario in polkadot-sdk and see how mortal txs work~ (works after using subxt correctly)
- ~look for unit tests that might be implemented in the repo~ (not that straight forward, useful thing to test is mortal/immortal txs creation, but we have integration tests in `polkadot-sdk` that covers it)
- ~maybe enable support for mixing mortal with immortal txs?~ (not really needed for now)